### PR TITLE
Add recent interviews & lectures (2021-2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@
   - AI IoT活用に価格破壊！「組み込みディープラーニング」世界へ
 - [安価な組み込みAIを世界へ！ Ideinが「高火力」を選んだ理由](http://ascii.jp/elem/000/001/726/1726225/)
 - [毎日新聞 2018年8月27日東京朝刊](https://mainichi.jp/articles/20180827/ddm/008/020/036000c)
+- [スタクラ CEOインタビュー](https://startupclass.co.jp/article/2021/05/18/idein/)
+- [週刊BCN+](https://www.weeklybcn.com/journal/era/detail/20220519_190937.html)
+- [PR TIMES STORY](https://prtimes.jp/story/detail/orokwqS8Myr)
+- [TECHBLITZ Startup Interview](https://techblitz.com/startup-interview/idein/)
 
 ## Works & Activities
 ### Software Projects
@@ -98,3 +102,7 @@
   - Presentation: [Accelerating deep learning inference on Raspberry Pi](https://www.youtube.com/watch?v=10RyDvTj4hc)
 - [The New Context Conference](http://ncc.garage.co.jp/ja/)
   - 2016 Tokyo (presentation & panel session), 2017 Tokyo (presentation & panel session), 2018 Tokyo (panel session)
+- [EdgeTech+ 2022](https://www.jasa.or.jp/expo/2022/)
+- [JETRO × Hello Tomorrow Japan 「Deep Techで世界を目指せ」](https://www.youtube.com/watch?v=2qKPoBe8w20)
+  - Panel session
+- [ILS2023 Innovation Leaders Summit](https://ils.tokyo/event_2023/)


### PR DESCRIPTION
🤖 自動生成（クラウドでWeb検索・検証 → ローカルからPR作成）。**マージ前にレビューしてください。**

直近のインタビュー・登壇を `Interviews` / `Lectures & Presentations` 節の末尾に追記しました（既存行は不変更）。各項目はURLの生存（HTTP 200）を確認済みで、可能な範囲で Idein 公式ニュースを根拠に裏取りしています。

### Interviews（4件）
- **スタクラ CEOインタビュー** — https://startupclass.co.jp/article/2021/05/18/idein/ （2021/05, Idein 中村のCEOインタビュー）
- **週刊BCN+** — https://www.weeklybcn.com/journal/era/detail/20220519_190937.html （2022/05, Idein公式ニュースで掲載確認）
- **PR TIMES STORY** — https://prtimes.jp/story/detail/orokwqS8Myr （Idein創業ストーリー）
- **TECHBLITZ Startup Interview** — https://techblitz.com/startup-interview/idein/ （2023/07, Idein公式 news/230724-techblitz で確認）

### Lectures & Presentations（3件）
- **EdgeTech+ 2022** — https://www.jasa.or.jp/expo/2022/ （2022/11, Idein公式 221111-edgetech2022-event で確認）
- **JETRO × Hello Tomorrow Japan「Deep Techで世界を目指せ」** — https://www.youtube.com/watch?v=2qKPoBe8w20 （2022/08, パネリスト）
- **ILS2023 Innovation Leaders Summit** — https://ils.tokyo/event_2023/ （2023/12, Idein公式 231110-ils2023-pitch で確認）

### レビュー観点
- タイトルは媒体名ベースの控えめな表記にしています。実際の記事/登壇タイトルに合わせて自由に調整してください。
- 不適切な項目があれば該当行を削除してください。
