### PR TITLE
プロフィール更新 2026-07: インタビュー2件・登壇3件を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 - [週刊BCN+](https://www.weeklybcn.com/journal/era/detail/20220519_190937.html)
 - [PR TIMES STORY](https://prtimes.jp/story/detail/orokwqS8Myr)
 - [TECHBLITZ Startup Interview](https://techblitz.com/startup-interview/idein/)
+- [ZUU online インタビュー](https://zuu.co.jp/media/stock/interview-idein)
+- [社長名鑑 業界特集インタビュー](https://shachomeikan.jp/industry_article/3215)
 
 ## Works & Activities
 ### Software Projects
@@ -106,3 +108,9 @@
 - [JETRO × Hello Tomorrow Japan 「Deep Techで世界を目指せ」](https://www.youtube.com/watch?v=2qKPoBe8w20)
   - Panel session
 - [ILS2023 Innovation Leaders Summit](https://ils.tokyo/event_2023/)
+- [SMART CITY REVERSE PITCH](https://www.idein.jp/ja/news/240126-smartcity-event)
+  - 対談登壇: スマートシティ領域のセクター横断協業事例
+- [MWC Barcelona 2025](https://www.idein.jp/ja/news/250128-kddi-mwc2025-ai-signage)
+  - KDDIスタートアップピッチ「Meet Japan's Next Unicorns!」登壇
+- [「製造業×AIで未来を創る」オンラインセミナー（さくらインターネット共催）](https://www.idein.jp/ja/news/sakura-internet-event-251001)
+  - Raspberry Pi × Actcastで現場発での工場DXを加速


### PR DESCRIPTION
🤖 自動生成。マージ前にレビューしてください

## 追加内容

### Interviews に追記（2件）

- **[ZUU online インタビュー](https://zuu.co.jp/media/stock/interview-idein)**
  - 公開日: 2025年12月24日
  - 媒体: ZUU online（株式投資・経済メディア）
  - 根拠: 中村晃一氏（Idein CEO）へのQ&Aインタビュー記事。エッジAIプラットフォームのグローバル展開戦略を語る内容。HTTP 200確認済み。

- **[社長名鑑 業界特集インタビュー](https://shachomeikan.jp/industry_article/3215)**
  - 公開日: 2024年10月
  - 媒体: 社長名鑑（業界特集記事メディア）
  - 根拠: Idein株式会社代表取締役 中村晃一氏へのQ&A形式インタビュー記事（「ーー」質問／「中村晃一：」回答の形式）。HTTP 200確認済み。

### Lectures & Presentations に追記（3件）

- **[SMART CITY REVERSE PITCH](https://www.idein.jp/ja/news/240126-smartcity-event)**
  - 日付: 2024年2月20日
  - 会場: Global Business Hub Tokyo（大手町）
  - 根拠: Idein公式ニュースページで「CEOの中村が対談登壇」と明記。テーマ「スマートシティ領域のセクター横断協業事例」。HTTP 200確認済み。

- **[MWC Barcelona 2025](https://www.idein.jp/ja/news/250128-kddi-mwc2025-ai-signage)**
  - 日付: 2025年3月5日 13:15〜13:45
  - 根拠: Idein公式ニュースで「代表取締役CEO 中村晃一がKDDIスタートアップピッチ『Meet Japan's Next Unicorns!』に登壇」と明記。世界最大のモバイル関連展示会。HTTP 200確認済み。

- **[「製造業×AIで未来を創る」オンラインセミナー（さくらインターネット共催）](https://www.idein.jp/ja/news/sakura-internet-event-251001)**
  - 日付: 2025年10月1日
  - 根拠: Idein公式ニュースで「弊社 代表取締役/CEO 中村晃一が登壇」「Raspberry Pi × Actcastで現場発での工場DXを加速」と明記。HTTP 200確認済み。

## 検索クエリ

- 中村晃一 Idein インタビュー 2024 2025
- 中村晃一 Idein 講演 登壇 2024 2025
- Koichi Nakamura Idein interview 2024 2025
- Idein 中村晃一 セミナー 2024 2025 2026
- 中村晃一 Idein 登壇 2024 2025 EdgeTech ILS スタートアップ
- 中村晃一 Idein 2024 2025 EdgeTech MWC スタートアップ 講演