### PR TITLE
README: 構成の組み替えと依頼窓口の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - [Speakerdeck](https://speakerdeck.com/nineties/)
 - [Qiita](https://qiita.com/9_ties)
 
+講演依頼・執筆依頼は koichi@idein.jp まで。
+
 ## Career
 
 - Born in 1984.
@@ -47,44 +49,6 @@
 - [INTLOOP Ventures 特別対談](https://www.intloop.com/intloopventures/interview/crosstalk1-3/)
 
 ## Works & Activities
-### Software Projects
-
-- [Amber](https://github.com/nineties/amber)
-  - [Creating a language using only assembly language](https://speakerdeck.com/nineties/creating-a-language-using-only-assembly-language)
-  - [アセンブリ言語のみで言語処理系を作った話](https://speakerdeck.com/nineties/bootstrap)
-- [py-videocore](https://github.com/nineties/py-videocore)
-  - Python library for GPGPU on Raspberry Pi
-- [PlanckForth](https://github.com/nineties/planckforth)
-  - Bootstrapping an Interpreter from Handwritten 1KB Binary
-
-### Hardware Projects
-
-- Actbulb (Past project at Idein. Not for sale)
-  - Smart lightbulb with vision sensors
-  - Circuit design, PCB design, 3D CAD
-
-![](images/actbulb.png)
-
-- PiZero Cluster Board (Past project at Idein. Not for sale)
-  - Circuit design, PCB design 
-
-![](images/pi0clusterboard.gif)
-
-- PiZero Drone HAT (Ongoing hobby project. Not for sale)
-  - Circuit design, PCB design, Mechanical design, flight controller
-
-![](images/drone.png)
-
-### Math Lectures or Materials
-(Only in japanese)
-
-- 圏論勉強会: [資料](http://nineties.github.io/category-seminar/) [動画](https://www.youtube.com/playlist?list=PLzJWjr7AvxH37O6GPqx20NpF0HaSrndVc)
-- プログラマの為の数学勉強会: [資料](http://nineties.github.io/math-seminar/) [動画](https://www.youtube.com/playlist?list=PLzJWjr7AvxH0YYpi2uAH_QHLaSJQ5fZrR)
-- パターン認識と機械学習勉強会: [資料](http://nineties.github.io/prml-seminar/) [動画](https://www.youtube.com/playlist?list=PLZUl2daVfjB2M2nzTBXWx5z_IA9u3Ob6x)
-- 機械学習に基づく自然言語処理勉強会: [資料](http://nineties.github.io/NLP-seminar/) [動画](https://www.youtube.com/playlist?list=PLl1oX4Yc8CJail3kBuQZJye6rKpS7hoHw)
-- 多様体上での最適化問題: [資料](https://nineties.github.io/manifold-optimization)
-- トポス理論: [資料](https://nineties.github.io/topos-theory/overview/)
-
 ### Lectures & Presentations
 
 - [SSII2019](https://confit.atlas.jp/guide/event/ssii2019/static/organized)
@@ -118,3 +82,41 @@
   - KDDIスタートアップピッチ「Meet Japan's Next Unicorns!」登壇
 - [「製造業×AIで未来を創る」オンラインセミナー（さくらインターネット共催）](https://www.idein.jp/ja/news/sakura-internet-event-251001)
   - Raspberry Pi × Actcastで現場発での工場DXを加速
+
+### Math Lectures or Materials
+(Only in japanese)
+
+- 圏論勉強会: [資料](http://nineties.github.io/category-seminar/) [動画](https://www.youtube.com/playlist?list=PLzJWjr7AvxH37O6GPqx20NpF0HaSrndVc)
+- プログラマの為の数学勉強会: [資料](http://nineties.github.io/math-seminar/) [動画](https://www.youtube.com/playlist?list=PLzJWjr7AvxH0YYpi2uAH_QHLaSJQ5fZrR)
+- パターン認識と機械学習勉強会: [資料](http://nineties.github.io/prml-seminar/) [動画](https://www.youtube.com/playlist?list=PLZUl2daVfjB2M2nzTBXWx5z_IA9u3Ob6x)
+- 機械学習に基づく自然言語処理勉強会: [資料](http://nineties.github.io/NLP-seminar/) [動画](https://www.youtube.com/playlist?list=PLl1oX4Yc8CJail3kBuQZJye6rKpS7hoHw)
+- 多様体上での最適化問題: [資料](https://nineties.github.io/manifold-optimization)
+- トポス理論: [資料](https://nineties.github.io/topos-theory/overview/)
+
+### Software Projects
+
+- [Amber](https://github.com/nineties/amber)
+  - [Creating a language using only assembly language](https://speakerdeck.com/nineties/creating-a-language-using-only-assembly-language)
+  - [アセンブリ言語のみで言語処理系を作った話](https://speakerdeck.com/nineties/bootstrap)
+- [py-videocore](https://github.com/nineties/py-videocore)
+  - Python library for GPGPU on Raspberry Pi
+- [PlanckForth](https://github.com/nineties/planckforth)
+  - Bootstrapping an Interpreter from Handwritten 1KB Binary
+
+### Hardware Projects
+
+- Actbulb (Past project at Idein. Not for sale)
+  - Smart lightbulb with vision sensors
+  - Circuit design, PCB design, 3D CAD
+
+![](images/actbulb.png)
+
+- PiZero Cluster Board (Past project at Idein. Not for sale)
+  - Circuit design, PCB design 
+
+![](images/pi0clusterboard.gif)
+
+- PiZero Drone HAT (Ongoing hobby project. Not for sale)
+  - Circuit design, PCB design, Mechanical design, flight controller
+
+![](images/drone.png)


### PR DESCRIPTION
- Works & Activities の並びを Lectures & Presentations → Math Lectures or Materials → Software Projects → Hardware Projects に変更。 講演と数学を上、写真を含む Hardware Projects を末尾にした
- Accounts の下に「講演依頼・執筆依頼は koichi@idein.jp まで。」を追加

本文の中身は動かしていない(各項目の文言・URLはそのまま)。