### PR TITLE
Google Analytics を GA4 に差し替え

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,4 +13,4 @@ github:
 # GA4 の測定ID (G-XXXXXXXXXX) を入れると有効になる。
 # 旧 UA-129434657-1 は Universal Analytics で、2023-07-01 に計測が停止しているため外した。
 # スニペットは _includes/head-custom-google-analytics.html で gtag.js に差し替え済み。
-google_analytics:
+google_analytics: G-YKPYB3GBTG

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
-repository: nineties/aboutme
+repository: nineties/nineties.github.io
 
 title: About Me
 logo: https://pbs.twimg.com/profile_images/797490964/PICT0031__1__Cartoonizer_1_400x400.jpg
@@ -10,4 +10,7 @@ github:
     - is_user_page: true
     - is_project_page: false
 
-google_analytics: UA-129434657-1
+# GA4 の測定ID (G-XXXXXXXXXX) を入れると有効になる。
+# 旧 UA-129434657-1 は Universal Analytics で、2023-07-01 に計測が停止しているため外した。
+# スニペットは _includes/head-custom-google-analytics.html で gtag.js に差し替え済み。
+google_analytics:

--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -1,0 +1,19 @@
+{%- comment -%}
+  テーマ (pages-themes/minimal) 同名ファイルの上書き。
+
+  テーマ側は Universal Analytics の analytics.js スニペットを出すが、
+  UA は 2023-07-01 に新規データの処理を停止しており、G- で始まる GA4 の
+  測定IDを入れても動かない。ここを GA4 (gtag.js) に差し替えている。
+
+  _config.yml の google_analytics に測定ID (G-XXXXXXXXXX) を入れると有効になる。
+  空のあいだは何も出力しない。
+{%- endcomment -%}
+{% if site.google_analytics %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics }}');
+  </script>
+{% endif %}


### PR DESCRIPTION
Universal Analytics を GA4 に差し替えます。

## いま起きていたこと

`_config.yml` に `google_analytics: UA-129434657-1` が入っていて、ページにも `analytics.js` のタグが出ていましたが、**Universal Analytics は 2023-07-01 に新規データの処理を停止**しています。タグは載っているがデータは取れていない状態でした。

## 測定IDの差し替えだけでは動かない

テーマ（pages-themes/minimal）の `_includes/head-custom-google-analytics.html` は、こう出力します。

```
ga('create', '{{ site.google_analytics }}', 'auto');
```

`G-` で始まる GA4 の測定IDをここに渡しても、UA の仕組みに入るだけで計測されません。

## 変更

- **`_includes/head-custom-google-analytics.html` を追加。** サイト側の `_includes` はテーマより優先されるので、テーマの同名ファイルを上書きして gtag.js のスニペットを出すようにした。`site.google_analytics` が空なら何も出力しない
- **`_config.yml`**: `google_analytics` を `G-YKPYB3GBTG` に。旧 `UA-129434657-1` は削除
- **`_config.yml`**: `repository` が `nineties/aboutme` のままだったので `nineties/nineties.github.io` に修正

## マージ後の確認

1. 数分待って `https://nineties.github.io/` のHTMLに `googletagmanager.com/gtag/js?id=G-YKPYB3GBTG` が出ているか
2. GA4 のリアルタイムで自分のアクセスが見えるか

2023年7月以降のアクセスデータは残っていないので、計測はこれからの分だけになります。
