### PR TITLE
メールアドレスをmailtoリンクにして、クリックをGA4で数える

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [Speakerdeck](https://speakerdeck.com/nineties/)
 - [Qiita](https://qiita.com/9_ties)
 
-講演依頼・執筆依頼は koichi@idein.jp まで。
+講演依頼・執筆依頼は [koichi@idein.jp](mailto:koichi@idein.jp) まで。
 
 ## 経歴
 

--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -16,4 +16,20 @@
     gtag('js', new Date());
     gtag('config', '{{ site.google_analytics }}');
   </script>
+
+  <script>
+    // メールアドレスのクリックを GA4 のイベントとして送る。
+    // GA4 の拡張計測の「離脱クリック」は http(s) の外部サイト向けリンクが対象で、
+    // mailto: は拾わない。数えたいならこうして自前でイベントを送る必要がある。
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('a[href^="mailto:"]').forEach(function (a) {
+        a.addEventListener('click', function () {
+          gtag('event', 'mail_click', {
+            link_url: a.href,
+            link_text: (a.textContent || '').trim()
+          });
+        });
+      });
+    });
+  </script>
 {% endif %}


### PR DESCRIPTION
「講演依頼・執筆依頼は koichi@idein.jp まで。」がただのテキストで、クリックできる要素が無かった。

- README.md — メールアドレスを `mailto:` リンクにした
- `_includes/head-custom-google-analytics.html` — mailto リンクのクリックで GA4 に `mail_click` イベントを送る

GA4 の拡張計測の「離脱クリック」は http(s) の外部サイト向けリンクが対象で `mailto:` は拾わないため、自前でイベントを送っている。GA4 の「レポート → エンゲージメント → イベント」に `mail_click` として出る。